### PR TITLE
fix(BaseCommand): get author from msg object rather than cache

### DIFF
--- a/src/structures/commands/BaseCommand.js
+++ b/src/structures/commands/BaseCommand.js
@@ -54,7 +54,7 @@ export default class BaseCommand extends Map {
     }
 
     get user() {
-        return this.users.get(this.msgObj.author);
+        return this.msgObj.author;
     }
 
     get users() {


### PR DESCRIPTION
Author doesn't exist in cache if it's disabled.

This PR returns the author's user object from the message object, rather than getting it from cache.